### PR TITLE
Add Android Studio requirement to getting started guide

### DIFF
--- a/src/content/docs/docs/gettingstarted.mdx
+++ b/src/content/docs/docs/gettingstarted.mdx
@@ -6,7 +6,7 @@ tableOfContents: false
 import { Steps } from '@astrojs/starlight/components';
 
 :::note[System Requirements]
-Skip requires a macOS 15+ development host with [Xcode 16](https://developer.apple.com/xcode) or later installed.
+Skip requires a macOS 15+ development host with [Xcode 16](https://developer.apple.com/xcode) or later and [Android Studio](https://developer.android.com/studio) installed.
 :::
 
 <Steps>


### PR DESCRIPTION
Apropos https://github.com/skiptools/skip/issues/606

I think we should fix https://github.com/skiptools/skip/issues/606 properly, but, for now, this will put people on the right track.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

